### PR TITLE
Remove deprecated extensions usage

### DIFF
--- a/samples/spa/src/main/java/com/webauthn4j/springframework/security/webauthn/sample/app/config/WebSecurityConfig.java
+++ b/samples/spa/src/main/java/com/webauthn4j/springframework/security/webauthn/sample/app/config/WebSecurityConfig.java
@@ -19,7 +19,7 @@ package com.webauthn4j.springframework.security.webauthn.sample.app.config;
 import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.data.PublicKeyCredentialType;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
-import com.webauthn4j.data.extension.client.SupportedExtensionsExtensionClientInput;
+import com.webauthn4j.data.extension.client.CredentialPropertiesExtensionClientInput;
 import com.webauthn4j.springframework.security.webauthn.authenticator.WebAuthnAuthenticatorService;
 import com.webauthn4j.springframework.security.webauthn.config.configurers.WebAuthnAuthenticationProviderConfigurer;
 import com.webauthn4j.springframework.security.webauthn.config.configurers.WebAuthnConfigurer;
@@ -111,7 +111,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .addPublicKeyCredParams(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256) // FIDO U2F Key, etc
                 .and()
                 .registrationExtensions()
-                .addExtension(new SupportedExtensionsExtensionClientInput(true))
+                .addExtension(new CredentialPropertiesExtensionClientInput(true))
                 .and();
 
 

--- a/webauthn4j-spring-security-core/src/test/java/com/webauthn4j/springframework/security/webauthn/config/configurers/WebAuthnLoginConfigurerSpringTest.java
+++ b/webauthn4j-spring-security-core/src/test/java/com/webauthn4j/springframework/security/webauthn/config/configurers/WebAuthnLoginConfigurerSpringTest.java
@@ -21,8 +21,8 @@ import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.PublicKeyCredentialType;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.data.client.challenge.DefaultChallenge;
+import com.webauthn4j.data.extension.client.CredentialPropertiesExtensionClientInput;
 import com.webauthn4j.data.extension.client.FIDOAppIDExtensionClientInput;
-import com.webauthn4j.data.extension.client.SupportedExtensionsExtensionClientInput;
 import com.webauthn4j.springframework.security.webauthn.WebAuthnProcessingFilter;
 import com.webauthn4j.springframework.security.webauthn.challenge.ChallengeRepository;
 import com.webauthn4j.springframework.security.webauthn.endpoint.OptionsEndpointFilter;
@@ -176,7 +176,7 @@ public class WebAuthnLoginConfigurerSpringTest {
                     .registrationTimeout(10000L)
                     .authenticationTimeout(20000L)
                     .registrationExtensions()
-                    .addExtension(new SupportedExtensionsExtensionClientInput(true))
+                    .addExtension(new CredentialPropertiesExtensionClientInput(true))
                     .and()
                     .authenticationExtensions()
                     .addExtension(new FIDOAppIDExtensionClientInput(""))


### PR DESCRIPTION
Since some extensions removed from WebAuthn Level2 Spec are deprecated in WebAuthn4J library (https://github.com/webauthn4j/webauthn4j/pull/285), remove these classes usage from webauthn4j-spring-security sample/test code.