### PR TITLE
Remove owaspDependencyCheck from gradle check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: if not "${{ secrets.SONAR_TOKEN }}" == "" gradlew jacocoTestReport sonarqube check javadoc asciidoc -Dsonar.organization=webauthn4j -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+        run: if not "${{ secrets.SONAR_TOKEN }}" == "" gradlew jacocoTestReport sonarqube check dependencyCheckAnalyze javadoc asciidoc -Dsonar.organization=webauthn4j -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_TOKEN }}
         shell: cmd

--- a/.github/workflows/pr-gate-ci.yml
+++ b/.github/workflows/pr-gate-ci.yml
@@ -64,6 +64,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: if not "${{ secrets.SONAR_TOKEN }}" == "" gradlew jacocoTestReport sonarqube check javadoc asciidoc -Dsonar.organization=webauthn4j -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+        run: if not "${{ secrets.SONAR_TOKEN }}" == "" gradlew jacocoTestReport sonarqube check dependencyCheckAnalyze javadoc asciidoc -Dsonar.organization=webauthn4j -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_TOKEN }}
         shell: cmd
-

--- a/build.gradle
+++ b/build.gradle
@@ -225,8 +225,6 @@ configure(allJavaProjects) {
         }
     }
 
-    check.dependsOn dependencyCheckAnalyze
-
 }
 
 asciidoctorj {


### PR DESCRIPTION
since it is too slow, not stable.
It is now executed only on Code Analysis pipelines.