### PR TITLE
MPA sample to use username instead of user to store authenticator

### DIFF
--- a/samples/mpa/src/main/java/com/webauthn4j/springframework/security/webauthn/sample/app/web/WebAuthnSampleController.java
+++ b/samples/mpa/src/main/java/com/webauthn4j/springframework/security/webauthn/sample/app/web/WebAuthnSampleController.java
@@ -154,7 +154,7 @@ public class WebAuthnSampleController {
 
 			WebAuthnAuthenticator authenticator = new WebAuthnAuthenticatorImpl(
 					"authenticator",
-					user,
+					user.getUsername(),
 					registrationRequestValidationResponse.getAttestationObject().getAuthenticatorData().getAttestedCredentialData(),
 					registrationRequestValidationResponse.getAttestationObject().getAttestationStatement(),
 					registrationRequestValidationResponse.getAttestationObject().getAuthenticatorData().getSignCount(),


### PR DESCRIPTION
Fixes #634

The MPA sample did use the user object instead of the username to store the authenticator. This caused the lookup, using the username, to find no allowed credentials. By using the username for storing and lookup, as does the SPA, this problem is gone.