### PR TITLE
Update Spring Security, Spring Boot BOM, mysql-connector-j, and hibernate validaror versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 buildscript {
     ext{
         //Plugins
-        springBootVersion = '2.7.5'
+        springBootVersion = '2.7.8'
         sonarqubeVersion = '3.5.0.2730'
         asciidoctorGradleVersion = "3.3.2"
         artifactoryVersion = '4.31.0'
@@ -27,8 +27,8 @@ buildscript {
 
         //Libraries
         webauthn4jVersion = '0.20.6.RELEASE'
-        springSecurityVersion = '5.7.5'
-        hibernateValidatorVersion = '6.2.4.Final'
+        springSecurityVersion = '5.7.6'
+        hibernateValidatorVersion = '6.2.5.Final'
         thymeleafVersion = '3.0.4.RELEASE'
         modelMapperVersion = '3.1.1'
 

--- a/samples/fido-server-conformance-test-app/build.gradle
+++ b/samples/fido-server-conformance-test-app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation('org.flywaydb:flyway-core')
     runtimeOnly('ch.qos.logback:logback-classic')
     runtimeOnly('com.h2database:h2')
-    runtimeOnly('mysql:mysql-connector-java')
+    runtimeOnly('com.mysql:mysql-connector-j')
     runtimeOnly("org.lazyluke:log4jdbc-remix")
 
     //Test

--- a/samples/spa/build.gradle
+++ b/samples/spa/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation('org.flywaydb:flyway-core')
     runtimeOnly('ch.qos.logback:logback-classic')
     runtimeOnly('com.h2database:h2')
-    runtimeOnly('mysql:mysql-connector-java')
+    runtimeOnly('com.mysql:mysql-connector-j')
     runtimeOnly("org.lazyluke:log4jdbc-remix")
 
     //Test

--- a/samples/spa/src/main/resources/application.yml
+++ b/samples/spa/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     encoding: UTF-8
     fallback-to-system-locale: false
   datasource:
-    url: jdbc:log4jdbc:h2:mem:webauthn;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=TRUE;MODE=MyS QL
+    url: jdbc:log4jdbc:h2:mem:webauthn;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=TRUE;MODE=MySQL
     driverClassName: net.sf.log4jdbc.DriverSpy
     username: sa
     password:

--- a/samples/spa/src/main/resources/application.yml
+++ b/samples/spa/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     encoding: UTF-8
     fallback-to-system-locale: false
   datasource:
-    url: jdbc:log4jdbc:h2:mem:webauthn;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=TRUE;MODE=MySQL
+    url: jdbc:log4jdbc:h2:mem:webauthn;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=TRUE;MODE=MyS QL
     driverClassName: net.sf.log4jdbc.DriverSpy
     username: sa
     password:


### PR DESCRIPTION
Update the version of spring related dependencies to the latest version used by the latest 2.7.x spring boot branches (version 2.7.8 at the moment of this MR/PR)

the 'mysql:mysql-connector-java' dependencies has been changed to 'com.mysql:mysql-connector-j' (the artifact was moved from mysql:mysql-connector-java to com.mysql:mysql-connector-j and the mysql:mysql-connector-java dependencies was not anymore in sping-boot-dependencies:2.7.8).

All unit tests passed and I was able to run the SPA and MPA examples (however I did not do exhaustive tests with them)