### PR TITLE
Updating spring security version to 5.7.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 
         //Libraries
         webauthn4jVersion = '0.21.0.RELEASE'
-        springSecurityVersion = '5.7.6'
+        springSecurityVersion = '5.7.7'
         hibernateValidatorVersion = '6.2.5.Final'
         thymeleafVersion = '3.0.4.RELEASE'
         modelMapperVersion = '3.1.1'


### PR DESCRIPTION
Updating Spring Security version to 5.7.7 instead 5.7.6 to be aligned with spring boot version 2.7.9.

For example the spring-boot-starter-security depends on version 5.7.7 of spring-security-config and spring-security-web.
