### PR TITLE
Remove dependabot for sample projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-- package-ecosystem: npm
-  directory: "/samples/lib/spa-angular-client"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 10


### PR DESCRIPTION
as sample projects are extracted to a dedicated repository